### PR TITLE
DKMS update support test

### DIFF
--- a/packaging/pikaos/regenerate_uki_dkms.install
+++ b/packaging/pikaos/regenerate_uki_dkms.install
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "add" ]; then
+        /etc/kernel/postinst.d/zzz-regenerate_uki "$2"
+fi
+
+if [ "$1" = "remove" ]; then
+        /etc/kernel/prerm.d/regenerate_uki "$2"
+fi


### PR DESCRIPTION
This adds a DKMS script to the packaging that *should* run after a dkms module is installed (based on the PR that would bring it into the package)